### PR TITLE
Discretization, hammer, difference between optimization and simulation, ramps, summary

### DIFF
--- a/prepare_data.py
+++ b/prepare_data.py
@@ -17,8 +17,7 @@ Julia.eval('ENV["OMP_NUM_THREADS"] = 8')
 Julia.eval('include("robot_dance.jl")')
 
 
-def save_basic_parameters(tinc=5.2, tinf=2.9, rep=2.5, ndays=400, window=14, min_level=1.0, 
-    hammer_level=0.89, hammer_duration=0):
+def save_basic_parameters(tinc=5.2, tinf=2.9, rep=2.5, ndays=400, window=14, min_level=1.0):
     """Save the basic_paramters.csv file using the data used in the report.
 
        All values are optional. If not present the values used in the report wihtout
@@ -31,8 +30,6 @@ def save_basic_parameters(tinc=5.2, tinf=2.9, rep=2.5, ndays=400, window=14, min
     basic_prm["ndays"] = ndays
     basic_prm["window"] = window
     basic_prm["min_level"] = min_level
-    basic_prm["hammer_level"] = hammer_level
-    basic_prm["hammer_duration"] = hammer_duration
     basic_prm.to_csv(path.join("data", "basic_parameters.csv"), header=False)
     return basic_prm
 
@@ -215,3 +212,12 @@ def save_target(cities_data, target):
     target_df = pd.DataFrame(data=target, index=cities_data.index, columns=days)
     target_df.to_csv(path.join("data", "target.csv"))
     return target_df
+
+def save_hammer_data(cities_data, duration=0, level=0.89):
+    """ Save hammer data
+    """
+    hammer_df = pd.DataFrame(index=cities_data.index)
+    hammer_df["duration"] = duration
+    hammer_df["level"] = level
+    hammer_df.to_csv(path.join("data", "hammer_data.csv"))
+    return hammer_df

--- a/robot_dance.jl
+++ b/robot_dance.jl
@@ -729,6 +729,31 @@ end
 
 
 """
+    add_ramp
+
+Adds ramp constraints to the robot-dance model.
+
+# Input arguments
+m: the optimization model
+prm: struct with parameters
+hammer_duration: initial hammer for each city
+delta_rt_max: max increase in the control rt between (t-1) and (t)
+
+# Output: the optimization model m
+"""
+function add_ramp(m, prm, hammer_duration, delta_rt_max)
+    println("Adding ramp constraints (delta_rt_max = $delta_rt_max)...")
+    rt = m[:rt]
+    @constraint(m, [c=1:prm.ncities, d = hammer_duration[c] + 1:prm.window:prm.ndays],
+    rt[c, d] - rt[c, d - prm.window] <= delta_rt_max
+    )
+    println("Adding ramp constraints (delta_rt_max = $delta_rt_max)... Ok!")
+
+    return m
+end
+
+
+"""
     simulate_control
 
 Simulate the SEIR mdel with a given control checking whether the target is achieved.

--- a/robot_dance.jl
+++ b/robot_dance.jl
@@ -468,7 +468,7 @@ function quadratic_seir_model_with_free_initial_values(prm)
         @expression(m, drp[c=1:prm.ncities, t=2:prm.ndays],
             (1.0/prm.tinf)*ip[c, t]
         )
-        println("Adding constraints for the intermediate point...")
+        println("Adding constraints for the intermediate point... Ok!")
 
         @constraint(m, [c=1:prm.ncities, t=2:prm.ndays],
             s[c, t] == s[c, t - 1] + 0.5*(ds[c, t - 1] + dsp[c, t])*dt

--- a/run_robot.py
+++ b/run_robot.py
@@ -514,14 +514,16 @@ def optimize_and_show_results(i_fig, rt_fig, data_file, large_cities):
 def main():
     """Allow call from the command line.
     """
+    dir_output = "results_central_no_ramp"
     options = get_options()
     basic_prm, cities_data, mob_matrix, target, hammer_data = read_data(options)
     ncities, ndays = len(cities_data.index), int(basic_prm["ndays"])
     force_dif = np.ones((ncities, ndays))
     find_feasible_hammer(basic_prm, cities_data, mob_matrix, target, hammer_data, options, incr_all=True, save_file=False)
     prepare_optimization(basic_prm, cities_data, mob_matrix, target, hammer_data, force_dif)
-    optimize_and_show_results("results/cmd_i_res.png", "results/cmd_rt_res.png",
-                              "results/cmd_res.csv", cities_data.index)
+    optimize_and_show_results(f"{dir_output}/cmd_i_res.png", f"{dir_output}/cmd_rt_res.png",
+                              f"{dir_output}/cmd_res.csv", cities_data.index)
+    # check_error_optim(basic_prm, cities_data, mob_matrix, dir_output)
 
 if __name__ == "__main__":
     main()

--- a/run_robot.py
+++ b/run_robot.py
@@ -93,6 +93,9 @@ def read_data(options):
     if path.exists(options.hammer_data):
         print('Reading hammer data...')
         hammer_data = pd.read_csv(options.hammer_data, index_col=0)
+        ncities = len(cities_data)
+        assert len(hammer_data.index) == ncities, \
+            "Different cities in cities data and hammer data"
         print('Reading hammer data... Ok!')
     else:
         print('Hammer data not found. Using default values')

--- a/run_robot.py
+++ b/run_robot.py
@@ -312,8 +312,6 @@ def main():
     """Allow call from the command line.
     """
     options = get_options()
-
-    breakpoint()
     basic_prm, cities_data, mob_matrix, target, hammer_data = read_data(options)
     ncities, ndays = len(cities_data.index), int(basic_prm["ndays"])
     force_dif = np.ones((ncities, ndays))

--- a/run_robot.py
+++ b/run_robot.py
@@ -139,7 +139,15 @@ def prepare_optimization(basic_prm, cities_data, mob_matrix, target, hammer_data
                                   sparse(M), sparse(M'))
             m = window_control_multcities(prm, population, target, force_dif, 
                                           hammer_duration, hammer_level, min_level);
-        """);        
+        """)
+
+    # Check if there is a ramp parameter (delta_rt_max)
+    # If so, add ramp constraints to the model
+    if 'delta_rt_max' in basic_prm:
+        Julia.delta_rt_max = basic_prm["delta_rt_max"]
+        Julia.eval("""
+            m = add_ramp(m, prm, hammer_duration, delta_rt_max)
+        """)
 
 
 def find_feasible_hammer(basic_prm, cities_data, mob_matrix, target, hammer_data, options, incr_all=False, save_file=False):

--- a/run_robot.py
+++ b/run_robot.py
@@ -311,17 +311,56 @@ def optimize_and_show_results(i_fig, rt_fig, data_file, large_cities):
     """)
 
     print('')
+    print('-----')
     print('Number of rt changes in each city')
     for (i, c) in enumerate(large_cities):
         changes_rt = len(np.diff(Julia.rt[i]).nonzero()[0]) + 1
         print(f'{c}: {changes_rt}')
+    print('-----')
 
     print('')
+    print('-----')
     print('Average fraction of infected')
     for (i, c) in enumerate(large_cities):
         i_avg = sum(Julia.i[i])/len(Julia.i[i])
         print(f'{c}: {i_avg}')
+    print('-----')
         
+    print('')
+    print('-----')
+    print('Number of days open (rt = 2.5)')
+    for (i,c) in enumerate(large_cities):
+        rt = Julia.rt[i]
+        inds = np.nonzero(rt >= 2.4)[0]
+        count_open_total = len(inds)
+        thresh_open = np.nonzero(np.diff(inds) > 1)[0] + 1
+        thresh_open = np.insert(thresh_open, 0, 0)
+        thresh_open = np.append(thresh_open, len(inds))
+        count_open = np.diff(thresh_open)
+        print(f'{c}: {count_open_total} days total')
+        for (i,n) in enumerate(count_open):
+            print(f'Opening {i+1}: {n} days')
+        print(f'Average: {np.mean(count_open):.0f} days')
+        print('')
+    print('-----')
+
+    print('')
+    print('-----')
+    print('Number of days in lockdown (rt <= 1.1)')
+    for (i,c) in enumerate(large_cities):
+        rt = Julia.rt[i]
+        inds = np.nonzero(rt <= 1.1)[0]
+        count_open_total = len(inds)
+        thresh_open = np.nonzero(np.diff(inds) > 1)[0] + 1
+        thresh_open = np.insert(thresh_open, 0, 0)
+        thresh_open = np.append(thresh_open, len(inds))
+        count_open = np.diff(thresh_open)
+        print(f'{c}: {count_open_total} days total')
+        for (i,n) in enumerate(count_open):
+            print(f'Lockdown {i+1}: {n} days')
+        print(f'Average: {np.mean(count_open):.0f} days')
+        print('')
+    print('-----')
 
     # Before saving anything, check if directory exists
     # Lets assume all output files are in the same directory


### PR DESCRIPTION
Discretization:
- included finite differences schemes for the discretization of seir equations. In the quadratic_seir_model_with_free_initial_values and nonlinear_seir_model_with_free_initial_values functions, now we set the variable discr_method as "heun" or "finite_difference". For the latter, we choose two weights k_curr_t and k_prev_t:
k_curr_t = 1.0 and k_prev_t = 0.0 : backward
k_curr_t = 0.5 and k_prev_t = 0.5 : central
k_curr_t = 0.0 and k_prev_t = 1.0 : forward

Hammer:
- user can choose duration (column 'duration') and level (column 'level') for each city (input option --hammer_data). Before optimizing, we now simulate the SEIR equations for such hammer and check if number of infected gets bigger than the target. If so, hammer duration is increased (by one window) until number of infected is below target.
- there are two ways of increasing hammer duration: all cities that violate the target at once, or separately. The first option is cheaper to, but it might result in a hammer duration bigger than necessary for some cities (for example, I think it's possible that increasing the hammer in one city might make a neighbour fall below its target). We choose this way of increasing with the argument incr_all in find_feasible_hammer (if True, all violating hammers are increased; if False, only the city with the biggest violation is increased)

Ramps:
- in the basic_parameters file, we now can have a parameter delta_rt_max. If such parameter is present, ramp constraints are added to the model:
rt[t] - rt[t-window] <= delta_rt_max

Summary:
- some info are printed after optimization, such as number of days open and in lockdown, number of changes in rt, etc